### PR TITLE
Add template helper and update kubectl

### DIFF
--- a/k8s/kubectl.groovy
+++ b/k8s/kubectl.groovy
@@ -198,6 +198,14 @@ kubectl get ${objectType} ${useContext} \
 }
 
 /*
+ * Check whether the given object exists.
+ */
+def checkObject(objectType, objectName, namespace = "default", context = null) {
+    def obj = getObject(objectType, objectName, namespace, context)
+    return obj != null
+}
+
+/*
  * Parse JSON string.
  */
 def parseJson(jsonString) {

--- a/util/file-template.groovy
+++ b/util/file-template.groovy
@@ -1,0 +1,31 @@
+#!/usr/bin/env groovy
+
+/*
+ ** Template Files helper.
+ * This module may be useful when you need to work with template files whose contents
+ * usually have placeholders that need to be replaced with any given values.
+ */
+
+/**
+ ** Function:
+ * Use the given source file contents as a template, replace all placeholders with
+ * the given placeholder values and save it to the given destination file.
+ *
+ ** Parameters:
+ * @param String srcFile Path to a file whose contents will be used as a template for replacing placeholders
+ * @param String destFile Path to a file that will hold the contents of the template after replacing its placeholders
+ * @param Map placeholderValues A list of key/value pairs that will be used for replacing placeholders
+ * @return
+ */
+def replace(String sourceFile, String destFile, HashMap placeholderValues, String placeholderDelimiter = '%') {
+    String fileContents = readFile sourceFile
+    
+    // Go through all placeholder items
+    for (def placeholderObj in placeholderValues) {
+        // Find and replace placeholders with its corresponding values
+        String placeholder = placeholderDelimiter + placeholderObj.key + placeholderDelimiter
+        fileContents = fileContents.replaceAll(/$placeholder/, placeholderObj.value)
+    }
+    
+    writeFile file: destFile, text: fileContents
+}

--- a/util/file-template.groovy
+++ b/util/file-template.groovy
@@ -29,3 +29,5 @@ def replace(String sourceFile, String destFile, HashMap placeholderValues, Strin
     
     writeFile file: destFile, text: fileContents
 }
+
+return this


### PR DESCRIPTION
- Update kubectl helper to include a function to check for objects.
- Add a helper to work with template files that contain placeholders that need to be replaced with any given values.